### PR TITLE
Add api and calls route, add tracking model

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,6 +60,8 @@ app.use(cookieParser())
 app.use(express.static(path.join(__dirname, 'dist')))
 
 app.use('/', index)
+app.use('/api', calls)
+app.use('/calls', calls)
 app.use('/api/apparatus', apparatus)
 app.use('/api/calls', calls)
 app.use('/api/carriers', carriers)

--- a/models/index.js
+++ b/models/index.js
@@ -46,8 +46,9 @@ db.calls = require('./call')(sequelize, Sequelize)
 db.carriers = require('./carrier')(sequelize, Sequelize)
 db.stations = require('./station')(sequelize, Sequelize)
 db.apparatus = require('./apparatus')(sequelize, Sequelize)
+db.tracking = require('./tracking')(sequelize, Sequelize)
 
-db.users.belongsToMany(db.apparatus, {through: 'tracking'});
-db.apparatus.belongsToMany(db.users, {through: 'tracking'});
+db.users.belongsToMany(db.apparatus, {as: 'users', through: db.tracking, foreignKey: 'userId'})
+db.apparatus.belongsToMany(db.users, {as: 'apparatus', through: db.tracking, foreignKey: 'apparatusId'})
 
 module.exports = db

--- a/models/tracking.js
+++ b/models/tracking.js
@@ -1,0 +1,24 @@
+/**
+ * models/tracking.js
+ *
+ * Join table between users and apparatus
+ *
+ * Sequelize will automatically create this table with foreign keys linked to
+ * apparatus.apparatusId and users.userId. This is achieved via the
+ * belongsToMany commands in the models/index.js file.
+ *
+ */
+'use strict'
+
+const Sequelize = require('sequelize')
+
+module.exports = (sequelize, DataTypes) => {
+  return sequelize.define('tracking', {
+    trackingId: {
+      type: Sequelize.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false
+    }
+  })
+}

--- a/routes/users.js
+++ b/routes/users.js
@@ -4,24 +4,7 @@
 
 const express = require('express')
 const router = express.Router()
-// const User = require('../models/user')
-// const Apparatus = require('../models/apparatus')
-// const Station = require('../models/station')
-// const Carrier = require('../models/carrier')
 const db = require('../models')
-
-// // GET all users listing
-// router.get('/', function (req, res, next) {
-//     var user = req.query.mobile
-//     User.scan().exec( (err, data) => {
-//       if (err) {
-//         console.error('DYNAMO USER FETCH ERROR: ', err)
-//       } else {
-//         // res.send(JSON.stringify(data))
-//         res.send(data)
-//       }
-//     })
-// })
 
 //TODO:  error proof and sort
 router.get('/', function (req, res, next) {
@@ -32,6 +15,5 @@ router.get('/', function (req, res, next) {
     res.send(allUsers)
   })
 })
-
 
 module.exports = router


### PR DESCRIPTION
The proper way to route and render calls is to /api/calls. But for the time being Nexgen may continue to send actual dispatch calls to /calls, so let's be there to receive them.  And having a sane default in place for /api just seems like a good idea.

The tracking model is added back in with just one field: trackingId.  Using Sequelize's belongsToMany command creates the foreign keys we need, but not a trackingId, hence this stub of a table. 